### PR TITLE
migration to .net 5

### DIFF
--- a/EPPlusSampleApp.Core.csproj
+++ b/EPPlusSampleApp.Core.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>EPPlusSamples</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
updated the csproj file to .net 5 because .netcore2.2 had reached its end of life